### PR TITLE
Bug Fixes for Recommendation Request Table

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -162,7 +162,7 @@ function App() {
           <>
             <Route
               exact
-              path="/recommendationrequest"
+              path="/recommendationrequests"
               element={<RecommendationRequestIndexPage />}
             />
           </>
@@ -171,36 +171,12 @@ function App() {
           <>
             <Route
               exact
-              path="/recommendationrequest/edit/:id"
+              path="/recommendationrequests/edit/:id"
               element={<RecommendationRequestEditPage />}
             />
             <Route
               exact
-              path="/recommendationrequest/create"
-              element={<RecommendationRequestCreatePage />}
-            />
-          </>
-        )}
-
-        {hasRole(currentUser, "ROLE_USER") && (
-          <>
-            <Route
-              exact
-              path="/recommendationrequest"
-              element={<RecommendationRequestIndexPage />}
-            />
-          </>
-        )}
-        {hasRole(currentUser, "ROLE_ADMIN") && (
-          <>
-            <Route
-              exact
-              path="/recommendationrequest/edit/:id"
-              element={<RecommendationRequestEditPage />}
-            />
-            <Route
-              exact
-              path="/recommendationrequest/create"
+              path="/recommendationrequests/create"
               element={<RecommendationRequestCreatePage />}
             />
           </>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -75,7 +75,7 @@ export default function AppNavbar({
                   <Nav.Link as={Link} to="/ucsbdates">
                     UCSB Dates
                   </Nav.Link>
-                  <Nav.Link as={Link} to="/recommendationrequest">
+                  <Nav.Link as={Link} to="/recommendationrequests">
                     Recommendation Requests
                   </Nav.Link>
                   <Nav.Link as={Link} to="/placeholder">

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -57,7 +57,7 @@ export default function RecommendationRequestTable({ requests, currentUser }) {
     },
     {
       Header: "Done",
-      accessor: "done",
+      accessor: (requests) => requests.done.toString(),
     },
   ];
 

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.js
@@ -38,7 +38,7 @@ export default function RecommendationRequestCreatePage({ storybook = false }) {
   };
 
   if (isSuccess && !storybook) {
-    return <Navigate to="/recommendationrequest" />;
+    return <Navigate to="/recommendationrequests" />;
   }
 
   return (

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.js
@@ -59,7 +59,7 @@ export default function RecommendationRequestEditPage({ storybook = false }) {
   };
 
   if (isSuccess && !storybook) {
-    return <Navigate to="/recommendationrequest" />;
+    return <Navigate to="/recommendationrequests" />;
   }
 
   return (

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.js
@@ -14,7 +14,7 @@ export default function RecommendationRequestIndexPage() {
       return (
         <Button
           variant="primary"
-          href="/recommendationrequest/create"
+          href="/recommendationrequests/create"
           style={{ float: "right" }}
         >
           Create Recommendation Request

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
@@ -47,7 +47,7 @@ describe("RecommendationRequestTable tests", () => {
       "explanation",
       "dateRequested",
       "dateNeeded",
-      "done",
+      "Done",
     ];
     const testId = "RecommendationRequestTable";
 
@@ -67,6 +67,9 @@ describe("RecommendationRequestTable tests", () => {
     expect(screen.getByTestId(`${testId}-cell-row-1-col-id`)).toHaveTextContent(
       "2",
     );
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-Done`),
+    ).toHaveTextContent("true");
 
     const editButton = screen.queryByTestId(
       `${testId}-cell-row-0-col-Edit-button`,
@@ -109,7 +112,7 @@ describe("RecommendationRequestTable tests", () => {
       "explanation",
       "dateRequested",
       "dateNeeded",
-      "done",
+      "Done",
     ];
     const testId = "RecommendationRequestTable";
 

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.js
@@ -140,6 +140,6 @@ describe("RecommendationRequestCreatePage tests", () => {
     expect(mockToast).toBeCalledWith(
       "New Recommendation Request Created - id: 17",
     );
-    expect(mockNavigate).toBeCalledWith({ to: "/recommendationrequest" });
+    expect(mockNavigate).toBeCalledWith({ to: "/recommendationrequests" });
   });
 });

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestEditPage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestEditPage.test.js
@@ -213,7 +213,7 @@ describe("RecommendationRequestEditPage tests", () => {
       expect(mockToast).toBeCalledWith(
         "Recommendation Request Updated - id: 17",
       );
-      expect(mockNavigate).toBeCalledWith({ to: "/recommendationrequest" });
+      expect(mockNavigate).toBeCalledWith({ to: "/recommendationrequests" });
 
       expect(axiosMock.history.put.length).toBe(1); // times called
       expect(axiosMock.history.put[0].params).toEqual({ id: 17 });

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.js
@@ -69,7 +69,7 @@ describe("UCSBDatesIndexPage tests", () => {
       ).toBeInTheDocument();
     });
     const button = screen.getByText(/Create Recommendation Request/);
-    expect(button).toHaveAttribute("href", "/recommendationrequest/create");
+    expect(button).toHaveAttribute("href", "/recommendationrequests/create");
     expect(button).toHaveAttribute("style", "float: right;");
   });
 


### PR DESCRIPTION
Before this change, the edit page was incorrectly routed to from the index page. The navigation routes were changed to fix this. In addition, the recommendation request table was not displaying the boolean value of 'done,' This was fixed by modifying the accessor in the table.